### PR TITLE
update demo.juttle.io link

### DIFF
--- a/index.html
+++ b/index.html
@@ -72,7 +72,7 @@
                                         Run juttles stored on your filesystem and see the results right in your browser.
                                     </p>
                                     <p>
-                                        Check out our <a href="http://demo.juttle.io/">demo environment</a>.
+                                        Check out our <a href="http://demo.juttle.io/?path=%2Fexamples%2Findex.juttle">demo environment</a>.
                                 </div>
                             </div>
                             <div class="col-md-7">


### PR DESCRIPTION
Link to "examples index page" at http://demo.juttle.io/?path=%2Fexamples%2Findex.juttle so the first screen the user sees isn't so blank.

@mnibecker @demmer 
